### PR TITLE
Added link to NIST author instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Organizations that have published guidelines:
 * [Microsoft](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
 * [Chromium](https://chromium.googlesource.com/chromium/src/+/master/styleguide/inclusive_code.md)
 * [Apple](https://developer.apple.com/news/?id=1o9zxsxl)
+* [NIST](https://www.nist.gov/nist-research-library/nist-technical-series-publications-author-instructions#inclusive)
 
 Other organizations working on changes to technical terminology:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Organizations that have published guidelines:
 * [Microsoft](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
 * [Chromium](https://chromium.googlesource.com/chromium/src/+/master/styleguide/inclusive_code.md)
 * [Apple](https://developer.apple.com/news/?id=1o9zxsxl)
-* [NIST](https://www.nist.gov/nist-research-library/nist-technical-series-publications-author-instructions#inclusive)
+* [NIST](https://nvlpubs.nist.gov/nistpubs/ir/2021/NIST.IR.8366.pdf)
 
 Other organizations working on changes to technical terminology:
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Organizations that have published guidelines:
 * [Microsoft](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
 * [Chromium](https://chromium.googlesource.com/chromium/src/+/master/styleguide/inclusive_code.md)
 * [Apple](https://developer.apple.com/news/?id=1o9zxsxl)
+* [NIST](https://www.nist.gov/nist-research-library/nist-technical-series-publications-author-instructions#inclusive)
 * [NIST](https://nvlpubs.nist.gov/nistpubs/ir/2021/NIST.IR.8366.pdf)
 
 Other organizations working on changes to technical terminology:


### PR DESCRIPTION
Wasn't sure whether to delete the link article discussing NIST plans in the "other organizations working on changes" section, so I left it.